### PR TITLE
Create consistently-named modules

### DIFF
--- a/lib/polyfill.rb
+++ b/lib/polyfill.rb
@@ -1,5 +1,5 @@
-require 'polyfill/version'
-require 'polyfill/internal_utils'
+require_relative 'polyfill/version'
+require_relative 'polyfill/internal_utils'
 
 module Polyfill
   module Module; end
@@ -236,8 +236,8 @@ def Polyfill(options = {}) # rubocop:disable Naming/MethodName
   end
 end
 
-require 'polyfill/v2_2'
-require 'polyfill/v2_3'
-require 'polyfill/v2_4'
-require 'polyfill/v2_5'
-require 'polyfill/v2_6'
+require_relative 'polyfill/v2_2'
+require_relative 'polyfill/v2_3'
+require_relative 'polyfill/v2_4'
+require_relative 'polyfill/v2_5'
+require_relative 'polyfill/v2_6'

--- a/lib/polyfill.rb
+++ b/lib/polyfill.rb
@@ -9,10 +9,12 @@ module Polyfill
       raise ArgumentError, "#{module_name} is a class not a module"
     end
 
+    version_option = options.delete(:version)
+
     #
     # parse options
     #
-    versions = InternalUtils.polyfill_versions_to_use(options.delete(:version))
+    versions = InternalUtils.polyfill_versions_to_use(version_option)
 
     unless options.empty?
       raise ArgumentError, "unknown keyword: #{options.first[0]}"
@@ -35,7 +37,7 @@ module Polyfill
     #
     # build the module to return
     #
-    InternalUtils.create_module do |mod|
+    InternalUtils.create_module(module_name, methods, options, version_option) do |mod|
       # make sure the methods get added if this module is included
       mod.singleton_class.send(:define_method, :included) do |base|
         modules.each do |module_to_add|
@@ -90,7 +92,7 @@ def Polyfill(options = {}) # rubocop:disable Naming/MethodName
   #
   # build the module to return
   #
-  Polyfill::InternalUtils.create_module do |mod|
+  Polyfill::InternalUtils.create_module(options) do |mod|
     objects.each do |object_name, methods|
       #
       # find all polyfills for the object across all versions

--- a/spec/polyfill/get_spec.rb
+++ b/spec/polyfill/get_spec.rb
@@ -65,6 +65,25 @@ RSpec.describe 'Polyfill.get' do
       expect(obj.respond_to?(:slice_after)).to be true
     end
 
+    it 'returns the same module across multiple calls with the same arguments' do
+      mod1 = Polyfill.get(:Enumerable, :all)
+      mod2 = Polyfill.get(:Enumerable, :all)
+      expect(mod1).to be mod2
+    end
+
+    it 'uses the same module name across multiple ruby invocations' do
+      mod1 = `ruby -r./lib/polyfill -e 'puts Polyfill.get(:Enumerable, :all).name'`
+      mod2 = `ruby -r./lib/polyfill -e 'puts Polyfill.get(:Enumerable, :all).name'`
+      expect(mod1).to eq(mod2)
+      expect(mod1).to start_with('Polyfill::Module::')
+    end
+
+    it 'returns a different module across multiple calls with the different arguments' do
+      mod1 = Polyfill.get(:Enumerable, :all)
+      mod2 = Polyfill.get(Enumerable, %i[to_h])
+      expect(mod1).to_not be mod2
+    end
+
     context 'with arguments' do
       context ':version' do
         it 'includes everything for a valid version number' do
@@ -78,6 +97,28 @@ RSpec.describe 'Polyfill.get' do
             expect(obj.respond_to?(:sum)).to be false
           end
           expect(obj.respond_to?(:slice_after)).to be true
+        end
+
+        it 'returns the same module across multiple calls with the same arguments' do
+          mod1 = Polyfill.get(:Enumerable, :all, version: '2.3')
+          mod2 = Polyfill.get(:Enumerable, :all, version: '2.3')
+          expect(mod1).to be mod2
+        end
+
+        it 'uses the same module name across multiple ruby invocations' do
+          mod1 = `ruby -r./lib/polyfill -e 'puts Polyfill.get(:Enumerable, :all, version: "2.3").name'`
+          mod2 = `ruby -r./lib/polyfill -e 'puts Polyfill.get(:Enumerable, :all, version: "2.3").name'`
+          expect(mod1).to eq(mod2)
+          expect(mod1).to start_with('Polyfill::Module::')
+        end
+
+        it 'returns a different module across multiple calls with the different arguments' do
+          mod1 = Polyfill.get(:Enumerable, :all, version: '2.3')
+          mod2 = Polyfill.get(:Enumerable, :all)
+          mod3 = Polyfill.get(:Enumerable, :all, version: '2.4')
+          expect(mod1).to_not be mod2
+          expect(mod1).to_not be mod3
+          expect(mod2).to_not be mod3
         end
       end
     end

--- a/spec/polyfill_spec.rb
+++ b/spec/polyfill_spec.rb
@@ -112,6 +112,25 @@ RSpec.describe 'Polyfill()' do
         end
       end
 
+      it 'returns the same module across multiple calls with the same arguments' do
+        mod1 = Polyfill(Enumerable: :all)
+        mod2 = Polyfill(Enumerable: :all)
+        expect(mod1).to be mod2
+      end
+
+      it 'uses the same module name across multiple ruby invocations' do
+        mod1 = `ruby -r./lib/polyfill -e 'puts Polyfill(Enumerable: :all).name'`
+        mod2 = `ruby -r./lib/polyfill -e 'puts Polyfill(Enumerable: :all).name'`
+        expect(mod1).to eq(mod2)
+        expect(mod1).to start_with('Polyfill::Module::')
+      end
+
+      it 'returns a different module across multiple calls with the different arguments' do
+        mod1 = Polyfill(Enumerable: :all)
+        mod2 = Polyfill(Enumerable: %w[#to_h])
+        expect(mod1).to_not be mod2
+      end
+
       context 'capitalized symbols are treated as class names' do
         it 'returns a Module named Polyfill::Module::*' do
           mod = Polyfill({})


### PR DESCRIPTION
The goal of this is to make `srb rbi gems` (from the 'sorbet' gem) is
repeatable when runs include polyfill (via sorbet-rails).

currently because the name is based on the object_id and the whims of
the universe this isn't the case.

The added benefit is we can reuse modules defined with the same
arguments. (this might be the primary reason to do this, but for me it's
a nice bonus). Also this will no doubt affect whatever tooling is
available for rbs files in ruby 3.0.0

because these methods are created arbitrarily based on keyword arguments
it seems like the safest thing to name these is a base64 encoded version
of those arguments. (or close to base 64, +-/= are invalid name
characters, so i change the invalid characters to 1 and 2 (preceeded
by _ because we're not using it otherwise, and it means that no matter
the input, it will be only created by an identical string)

---

to show the objects it generates are repeatable across ruby runs

1. get sorbet gem
2. run `srb rbi hidden-definitions`
3. commit the generated files
4. run `srb rbi hidden-definitions` again.
5. there should be no change to sorbet/rbi/hidden-definitions/hidden.rbi