### PR TITLE
Run tests against ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.7
   - 2.6
   - 2.5
   - 2.4

--- a/spec/polyfill/v2_3/string/class/new_spec.rb
+++ b/spec/polyfill/v2_3/string/class/new_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'String.new' do
     end
 
     it 'throws an error on other unknown keywords' do
-      expect { String.new(unknown_keyword: true) }.to raise_error(ArgumentError, 'unknown keyword: unknown_keyword')
+      expect { String.new(unknown_keyword: true) }.to raise_error(ArgumentError, /unknown keyword: :?unknown_keyword/)
     end
   end
 end

--- a/spec/polyfill/v2_4/array/instance/concat_spec.rb
+++ b/spec/polyfill/v2_4/array/instance/concat_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe 'Array#concat' do
     end
 
     it 'keeps tainted status' do
+      skip '2.7 has made taint a no-op' if Polyfill::InternalUtils.current_ruby_version.to_f >= 2.7
+
       ary = [1, 2]
       ary.taint
       ary.concat([3])
@@ -56,6 +58,8 @@ RSpec.describe 'Array#concat' do
     end
 
     it 'is not infected by the other' do
+      skip '2.7 has made taint a no-op' if Polyfill::InternalUtils.current_ruby_version.to_f >= 2.7
+
       ary = [1, 2]
       other = [3]
       other.taint
@@ -65,6 +69,8 @@ RSpec.describe 'Array#concat' do
     end
 
     it 'keeps the tainted status of elements' do
+      skip '2.7 has made taint a no-op' if Polyfill::InternalUtils.current_ruby_version.to_f >= 2.7
+
       ary = [Object.new, Object.new, Object.new]
       ary.each(&:taint)
 

--- a/spec/polyfill/v2_5/string/instance/delete_prefix_spec.rb
+++ b/spec/polyfill/v2_5/string/instance/delete_prefix_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe 'String#delete_prefix' do
   end
 
   it 'taints resulting strings when other is tainted' do
+    skip '2.7 has made taint a no-op' if Polyfill::InternalUtils.current_ruby_version.to_f >= 2.7
+
     expect('hello'.taint.delete_prefix('hell').tainted?).to be true
     expect('hello'.taint.delete_prefix('').tainted?).to be true
   end

--- a/spec/polyfill/v2_5/string/instance/delete_suffix_spec.rb
+++ b/spec/polyfill/v2_5/string/instance/delete_suffix_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe 'String#delete_suffix' do
   end
 
   it 'taints resulting strings when other is tainted' do
+    skip '2.7 has made taint a no-op' if Polyfill::InternalUtils.current_ruby_version.to_f >= 2.7
+
     expect('hello'.taint.delete_suffix('ello').tainted?).to be true
     expect('hello'.taint.delete_suffix('').tainted?).to be true
   end


### PR DESCRIPTION
The main thing is skipping the tests concerned with preserving the
tainted state of strings because ruby 2.7 has made .taint a noop

I realise this is a polyfill library, but that's a pretty big thing to
polyfill

The only other test failure was due to a slightly different error
message for ArgumentError which feels much less controversial